### PR TITLE
Fix imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,10 +23,7 @@ let package = Package(
             name: "RAPChat",
             path: "RAPChat",
             sources: [""],
-            publicHeadersPath: "",
-            cSettings: [
-                .define("RAP_SWIFT_PACKAGE"),
-            ]
+            publicHeadersPath: ""
         ),
         .testTarget(
             name: "RAPChatTests",

--- a/RAPChat/include/RAPChat.h
+++ b/RAPChat/include/RAPChat.h
@@ -6,8 +6,6 @@
 //
 //
 
-#ifndef RAP_SWIFT_PACKAGE
-
 #import <Foundation/Foundation.h>
 
 //! Project version number for Peertalk.
@@ -19,8 +17,6 @@ FOUNDATION_EXPORT const unsigned char RAPChatVersionString[];
 // In this header, you should import all the public headers of your framework using statements like #import <Peertalk/PublicHeader.h>
 
 
-#import <RAPChat/PTChannel.h>
-#import <RAPChat/PTProtocol.h>
-#import <RAPChat/PTUSBHub.h>
-
-#endif
+#import <PTChannel.h>
+#import <PTProtocol.h>
+#import <PTUSBHub.h>

--- a/peertalk.xcodeproj/project.pbxproj
+++ b/peertalk.xcodeproj/project.pbxproj
@@ -298,8 +298,8 @@
 		6A88FA39150D613800FC3647 /* peertalk */ = {
 			isa = PBXGroup;
 			children = (
+				FA8E71D6235FC4B000E49ED3 /* include */,
 				6A4010D515275E3800EF0E92 /* prefix.pch */,
-				EE158A7C1CBD402600A3E3F0 /* RAPChat.h */,
 				5E2C5023171F46A6008A9752 /* PTPrivate.h */,
 				6ACFD2D4151D36220081ACF5 /* PTChannel.h */,
 				6ACFD2D5151D36220081ACF5 /* PTChannel.m */,
@@ -330,6 +330,14 @@
 				6A88FA4E150D613800FC3647 /* InfoPlist.strings */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		FA8E71D6235FC4B000E49ED3 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				EE158A7C1CBD402600A3E3F0 /* RAPChat.h */,
+			);
+			path = include;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
Fixes imports when used as a Swift Package.

Also tested with the example projects (i.e. building frameworks from Xcode) and they're still working fine.